### PR TITLE
Setup for Setsail

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -126,7 +126,7 @@ resource "aws_s3_bucket_policy" "s3fs_bucket_policy" {
 
 data "aws_iam_policy_document" "s3fs_bucket_policy" {
   statement {
-    actions = ["s3:ListBucket", "s3:GetObject"]
+    actions = ["s3:ListBucket"]
     resources = [aws_s3_bucket.s3fs_bucket.arn]
     principals {
       type        = "AWS"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -137,7 +137,7 @@ data "aws_iam_policy_document" "s3fs_bucket_policy" {
   }
 
   statement {
-    actions = ["s3:GetObject"]
+    actions = ["s3:GetObject", "s3:GetObjectTagging"]
     resources = ["${aws_s3_bucket.s3fs_bucket.arn}/*"]
     principals {
       type        = "AWS"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -71,11 +71,6 @@ data "aws_iam_policy_document" "s3fs_access_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "ec2_attach_policy" {
-  role       = aws_iam_role.ec2_role.name
-  policy_arn = aws_iam_policy.s3fs_access_policy.arn
-}
-
 resource "aws_launch_template" "ssm_ami_launch_template" {
   image_id               = data.aws_ssm_parameter.ngap_ami.value
   instance_type          = "${var.instance_size}"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -126,7 +126,7 @@ resource "aws_s3_bucket_policy" "s3fs_bucket_policy" {
 
 data "aws_iam_policy_document" "s3fs_bucket_policy" {
   statement {
-    actions = ["s3:ListBucket"]
+    actions = ["s3:ListBucket", "s3:GetObject"]
     resources = [aws_s3_bucket.s3fs_bucket.arn]
     principals {
       type        = "AWS"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -55,22 +55,20 @@ resource "aws_iam_instance_profile" "ec2_instance_profile" {
   role = aws_iam_role.ec2_role.name
 }
 
-resource "aws_iam_policy" "s3fs_access_policy" {
-  name        = "${local.resource_prefix}-S3FSAccessPolicy"
+resource "aws_iam_role_policy" "s3fs_access_policy" {
+  name   = "${local.resource_prefix}-S3FSAccessPolicy"
+  role   = aws_iam_role.ec2_role.id
+  policy = data.aws_iam_policy_document.s3fs_access_policy.minified_json
+}
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["s3:*"]
-        Resource = [
-          aws_s3_bucket.s3fs_bucket.arn,
-          "${aws_s3_bucket.s3fs_bucket.arn}/*"
-        ]
-      }
+data "aws_iam_policy_document" "s3fs_access_policy" {
+  statement {
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.s3fs_bucket.arn,
+      "${aws_s3_bucket.s3fs_bucket.arn}/*"
     ]
-  })
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "ec2_attach_policy" {
@@ -122,6 +120,37 @@ resource "aws_launch_template" "ssm_ami_launch_template" {
 # S3FS bucket + directories
 resource "aws_s3_bucket" "s3fs_bucket" {
   bucket = "${local.resource_prefix}-ec2"
+}
+
+resource "aws_s3_bucket_policy" "s3fs_bucket_policy" {
+  count = length(var.read_only_accounts) > 0 ? 1 : 0
+
+  bucket = aws_s3_bucket.s3fs_bucket.id
+  policy = data.aws_iam_policy_document.s3fs_bucket_policy.minified_json
+}
+
+data "aws_iam_policy_document" "s3fs_bucket_policy" {
+  statement {
+    actions = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.s3fs_bucket.arn]
+    principals {
+      type        = "AWS"
+      identifiers = [
+        for account in var.read_only_accounts : "arn:aws:iam::${account}:root"
+      ]
+    }
+  }
+
+  statement {
+    actions = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.s3fs_bucket.arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [
+        for account in var.read_only_accounts : "arn:aws:iam::${account}:root"
+      ]
+    }
+  }
 }
 
 resource "aws_s3_object" "s3fs_directories" {

--- a/terraform/envs/ops-cumulus.env
+++ b/terraform/envs/ops-cumulus.env
@@ -1,3 +1,4 @@
 export REGION=us-west-2
 export BUCKET=podaac-ops-cumulus-tf-state
 export TF_VAR_rotation_period=0
+export TF_VAR_instance_size=t3.large

--- a/terraform/envs/ops-cumulus.env
+++ b/terraform/envs/ops-cumulus.env
@@ -1,0 +1,3 @@
+export REGION=us-west-2
+export BUCKET=podaac-ops-cumulus-tf-state
+export TF_VAR_rotation_period=0

--- a/terraform/envs/ops-cumulus.env
+++ b/terraform/envs/ops-cumulus.env
@@ -1,3 +1,0 @@
-export REGION=us-west-2
-export BUCKET=podaac-ops-cumulus-tf-state
-export TF_VAR_rotation_period=0

--- a/terraform/envs/swot-uat.env
+++ b/terraform/envs/swot-uat.env
@@ -1,0 +1,3 @@
+export REGION=us-west-2
+export BUCKET=podaac-swot-uat-cumulus-tf-state
+export TF_VAR_rotation_period=0

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,6 +54,12 @@ variable "ami_ssm_key" {
     default = "/ngap/amis/image_id_al2023_x86"
 }
 
+variable "read_only_accounts" {
+    description = "List of AWS account IDs that can read the S3 buckets."
+    type        = list(string)
+    default     = []
+}
+
 variable "rotation_period" {
   default = 1
   description = "Value in days to rotate the EC2 AMI. Set to 0 to disable rotation."

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -41,7 +41,7 @@ echo "====== Install Ansible ======"
 yum install ansible -y
 
 echo "====== Run Ansibles ======"
-for site in $(find /bootstrap -L -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do
+for site in $(find -L /bootstrap -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do
     echo "Found $site"
     ansible-playbook "$site" -v -i localhost, --connection=local
 done

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -41,7 +41,7 @@ echo "====== Install Ansible ======"
 yum install ansible -y
 
 echo "====== Run Ansibles ======"
-for site in $(find /bootstrap -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do
+for site in $(find /bootstrap -L -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do
     echo "Found $site"
     ansible-playbook "$site" -v -i localhost, --connection=local
 done


### PR DESCRIPTION
Prepare Carpathia infrastructure for `setsail` integration in several environments

- OPS environment config
- UAT environment config
- SWOT-UAT environment config
- Allow readonly access to s3fs bucket to allow `setsail` to read UAT configs
- Some IAM policy cleanup