### PR TITLE
Verbose Initialization Messages and Reorder Initialization Steps

### DIFF
--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -23,4 +23,8 @@ resource "aws_sns_topic_subscription" "notification_emails" {
   topic_arn  = aws_sns_topic.ami_rotation.arn
   protocol   = "email"
   endpoint   = each.value
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -68,8 +68,10 @@ mkdir -p /persistent
 echo "====== Update FSTAB with Persistent ======"
 echo "s3fs#${s3fs_bucket_name} /persistent fuse _netdev,iam_role=auto,allow_other,use_cache=/tmp,uid=1001,gid=1001,umask=0022 0 0" >> /etc/fstab
 
-echo "====== Move current home directory ======"
+echo "====== Create new home directory ======"
 mv /home/ssm-user /home/ssm-user.tmp
+mkdir /home/ssm-user
+chown ssm-user:ssm-user /home/ssm-user
 
 echo "====== Mount It ALL ======"
 mount -a

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -1,4 +1,45 @@
 #!/bin/bash
+set -eo pipefail
+
+function error_handler {
+    cat << EOF > /etc/carpathia_status
+--- CARPATHIA INITIALIZATION FAILED ---
+An error occurred during the execution of the user-data script.
+Please check the logs for more details.
+EOF
+}
+
+trap error_handler ERR
+
+cat << EOF > /etc/carpathia_status
+--- CARPATHIA IS INITIALIZING ---
+The instance will be unstable for a few minutes while the setup is in progress.
+Please wait until the setup is complete before using the instance.
+EOF
+
+echo "====== Inject bash hook ======"
+# Override original /bin/bash with custom init script
+mv /bin/bash /bin/bash.real
+cat << EOF > /bin/bash
+#!/bin/bash.real
+if [ "\$(whoami)" == "ssm-user" ] && [ "\$SHLVL" == "1" ]; then
+  # Make the terminal look nice
+  export PS1='[\u@\h \W]\$ '
+
+  cd ~
+
+  # if /etc/carpathia_status exists, display its contents
+  if [ -f /etc/carpathia_status ]; then
+    cat /etc/carpathia_status
+  fi
+
+  # Source the .bashrc only when logging in as ssm-user
+  source ~/.bashrc
+fi
+
+exec /bin/bash.real "\$@"
+EOF
+chmod +x /bin/bash
 
 echo "====== Install Fuse Prerequisite ======"
 yum install automake fuse fuse-devel gcc-c++ git libcurl-devel libxml2-devel make openssl-devel -y
@@ -27,14 +68,14 @@ mkdir -p /persistent
 echo "====== Update FSTAB with Persistent ======"
 echo "s3fs#${s3fs_bucket_name} /persistent fuse _netdev,iam_role=auto,allow_other,use_cache=/tmp,uid=1001,gid=1001,umask=0022 0 0" >> /etc/fstab
 
+echo "====== Move current home directory ======"
+mv /home/ssm-user /home/ssm-user.tmp
+
 echo "====== Mount It ALL ======"
 mount -a
 
-echo "====== Wait for s3fs boostrap mount ======"
-while ! grep -q -s "s3fs /bootstrap" /proc/mounts; do
-        echo "Waiting for /bootstrap mount"
-        sleep 10
-done
+echo "====== Delete old home directory ======"
+rm -rf /home/ssm-user.tmp
 
 echo "====== Install Ansible ======"
 # Need to install Ansible here because it breaks otherwise
@@ -46,25 +87,7 @@ for site in $(find /bootstrap -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/
     ansible-playbook "$site" -v -i localhost, --connection=local
 done
 
-echo "====== Inject bash hook ======"
-# Override original /bin/bash with custom init script
-mv /bin/bash /bin/bash.real
-cat << EOF > /bin/bash
-#!/bin/bash.real
-if [ "\$(whoami)" == "ssm-user" ] && [ "\$SHLVL" == "1" ]; then
-  # Make the terminal look nice
-  export PS1='[\u@\h \W]\$ '
-
-  cd ~
-
-  # Source the .bashrc only when logging in as ssm-user
-  source ~/.bashrc
-fi
-
-exec /bin/bash.real "\$@"
-EOF
-chmod +x /bin/bash
-
+echo "====== Write .bashrc for ssm-user if doesn't exist ======"
 # Write .bashrc for ssm-user if doesn't exist
 if ! [ -f "/home/ssm-user/.bashrc" ]; then
   cat << EOF > /home/ssm-user/.bashrc
@@ -78,5 +101,7 @@ TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metad
 AMI_ID=`curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ami-id`
 echo -n "$AMI_ID" > /bootstrap/ami_id
 
+echo "====== Clean up ======"
+rm /etc/carpathia_status
 
 echo "====== DONE with User Data ======"

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -62,11 +62,11 @@ for dir in ${s3fs_directories}; do
     echo "s3fs#${s3fs_bucket_name}:/$dir /$dir fuse _netdev,iam_role=auto,allow_other,use_cache=/tmp,uid=1001,gid=1001,umask=0022 0 0" >> /etc/fstab
 done
 
-echo "====== Create Persistent ======"
-mkdir -p /persistent
-
 echo "====== Update FSTAB with Persistent ======"
 echo "s3fs#${s3fs_bucket_name} /persistent fuse _netdev,iam_role=auto,allow_other,use_cache=/tmp,uid=1001,gid=1001,umask=0022 0 0" >> /etc/fstab
+
+echo "====== Create Persistent ======"
+mkdir -p /persistent
 
 echo "====== Create new home directory ======"
 mv /home/ssm-user /home/ssm-user.tmp


### PR DESCRIPTION
Ticket(s): [PODAAC-7105](https://jira.jpl.nasa.gov/browse/PODAAC-7105)

- Solves race condition issue where initialization would sometimes cause `sudo` to stop working depending on when a user connects
- Make instance state more visible upon login to display if initialization has failed or if the system is still initializing
  - Implements "smoke test" requirements