### PR TITLE
Terraform Quality of Life Improvements

### DIFF
--- a/terraform/bin/config.sh
+++ b/terraform/bin/config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [ ! $# -eq 1 ]
+if [ $# -eq 0 ]
 then
     echo "$(caller | cut -d' ' -f2) venue"
     exit 1
@@ -12,6 +12,10 @@ shift
 
 cd "$(dirname $BASH_SOURCE)/../"
 source "envs/$VENUE.env"
+
+if [ -f "envs/$VENUE.secrets.env" ]; then
+  source "envs/$VENUE.secrets.env"
+fi
 
 export TF_IN_AUTOMATION=true  # https://www.terraform.io/cli/config/environment-variables#tf_in_automation
 export TF_INPUT=false  # https://www.terraform.io/cli/config/environment-variables#tf_input

--- a/terraform/bin/deploy.sh
+++ b/terraform/bin/deploy.sh
@@ -2,4 +2,4 @@
 set -eo pipefail
 
 source "$(dirname $BASH_SOURCE)/config.sh"
-terraform apply
+terraform apply $@

--- a/terraform/bin/destroy.sh
+++ b/terraform/bin/destroy.sh
@@ -2,4 +2,4 @@
 set -eo pipefail
 
 source "$(dirname $BASH_SOURCE)/config.sh"
-terraform destroy
+terraform destroy $@

--- a/terraform/envs/.gitignore
+++ b/terraform/envs/.gitignore
@@ -1,0 +1,1 @@
+*.secrets.env


### PR DESCRIPTION
Some quality of life fixes _not related to a ticket_ for the Terraform deployment scripts

- Load *.secrets.env files to allow for per-env secrets as part of the deploy.sh script
  - Added *.secrets.env to .gitignore
- Passthrough of arguments to the underlying terraform apply/destroy commands