### PR TITLE
Fix intermittent sudo issue on Carpathia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## 1.0.1
 
+- Fixed intermittent sudo isue
 - Fixed issue with bash wrapper not properly passing arguments to real bash exec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## 1.0.1
 
-- Fixed intermittent sudo isue
+- Fixed intermittent sudo issue
 - Fixed issue with bash wrapper not properly passing arguments to real bash exec

--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -69,14 +69,16 @@ echo "====== Create Persistent ======"
 mkdir -p /persistent
 
 echo "====== Create new home directory ======"
-mv /home/ssm-user /home/ssm-user.tmp
-mkdir /home/ssm-user
+mkdir -p /home/ssm-user # Create home directory if doesn't exist
+rm -rf /home/ssm-user/* # Delete anything inside if it already exists
+
+echo "====== Ensure ssm-user is in sudoers ======"
+if ! [ -f "/etc/sudoers.d/ssm-agent-users" ]; then
+  echo "ssm-user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ssm-agent-users
+fi
 
 echo "====== Mount It ALL ======"
 mount -a
-
-echo "====== Delete old home directory ======"
-rm -rf /home/ssm-user.tmp
 
 echo "====== Install Ansible ======"
 # Need to install Ansible here because it breaks otherwise


### PR DESCRIPTION
Ticket: [PODAAC-7124](https://jira.jpl.nasa.gov/browse/PODAAC-7124)

Write the `/etc/sudoers.d/ssm-agent-users` file that SSM normally injects during the first session connection if it doesn't already exist during the bootstrap process. Resolves the race condition between the finish of the home directory mount and the first SSM session connection