### PR TITLE
Persist crontabs across Carpathia resets

### DIFF
--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -78,6 +78,12 @@ mount -a
 echo "====== Delete old home directory ======"
 rm -rf /home/ssm-user.tmp
 
+echo "====== Crontab Persistence ======"
+touch /home/ssm-user/.crontab # Ensure the crontab exists
+rm -f /var/spool/cron/ssm-user
+ln -s /home/ssm-user/.crontab /var/spool/cron/ssm-user
+systemctl restart crond.service # Not sure if this is needed, but can't hurt
+
 echo "====== Install Ansible ======"
 # Need to install Ansible here because it breaks otherwise
 yum install ansible -y


### PR DESCRIPTION
Ticket: [PODAAC-7123](https://jira.jpl.nasa.gov/browse/PODAAC-7123)

Create a symlink during bootstrap which links `/home/ssm-user/.crontab` over to `/var/spool/cron/ssm-user` which allows persistence of the user crontab through resets of Carpathia