### PR TITLE
Enable logging of Carpathia EC2 events to CloudWatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
-## 1.0.1
+All notable changes to this project will be documented in this file.
 
-- Fixed issue with bash wrapper not properly passing arguments to real bash exec
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- CloudWatch logging for kernel messages, bootstrap logs, and command lines
+
+### Changed
+
+### Removed
+
+## [0.1.0]
+
+### Added
+
+- SIT/UAT deployment configurations
+- SNS notifications on instance rotation
+- Variable rotation periods dependent on last rotation instead of calendar date
+- Verbose initialization messages at top of session to indicate Carpathia status
+- Support for passing through Terraform arguments to deploy/destroy scripts
+- Setsail configurations/support
+
+### Fixed
+
+- Crontab non-persistence
+- Intermittent sudo issues with password prompts
+- Initialization messages not appearing due to early script exits
+- Environment rotation misconfigurations
+- S3FS mounts failing due to incorrect prefixes
+
+### Changed
+
+- UAT/OPS machine instance sizes changed to higher instance types for higher memory
+
+### Removed
+
+- Older deployment configuration styles

--- a/bootstrap/bootstrap.sh.tftpl
+++ b/bootstrap/bootstrap.sh.tftpl
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+# -- Setup bash error handler --
+
 function error_handler {
     cat << EOF > /etc/carpathia_status
 --- CARPATHIA INITIALIZATION FAILED ---
@@ -10,39 +12,6 @@ EOF
 }
 
 trap error_handler ERR
-
-cat << EOF > /etc/carpathia_status
---- CARPATHIA IS INITIALIZING ---
-The instance will be unstable for a few minutes while the setup is in progress.
-Please wait until the setup is complete before using the instance.
-EOF
-
-echo "====== Inject bash hook ======"
-# Override original /bin/bash with custom init script
-mv /bin/bash /bin/bash.real
-cat << EOF > /bin/bash
-#!/bin/bash.real
-if [ "\$(whoami)" == "ssm-user" ] && [ "\$SHLVL" == "1" ]; then
-  # Make the terminal look nice
-  export PS1='[\u@\h \W]\$ '
-
-  cd ~
-
-  # if /etc/carpathia_status exists, display its contents
-  if [ -f /etc/carpathia_status ]; then
-    cat /etc/carpathia_status
-  fi
-
-  # Source the .bashrc only when logging in as ssm-user
-  source ~/.bashrc
-fi
-
-exec /bin/bash.real "\$@"
-EOF
-chmod +x /bin/bash
-
-echo "====== Install Fuse Prerequisite ======"
-yum install automake fuse fuse-devel gcc-c++ git libcurl-devel libxml2-devel make openssl-devel -y
 
 echo "====== Download S3FS ======"
 git clone https://github.com/s3fs-fuse/s3fs-fuse.git
@@ -77,10 +46,6 @@ mount -a
 
 echo "====== Delete old home directory ======"
 rm -rf /home/ssm-user.tmp
-
-echo "====== Install Ansible ======"
-# Need to install Ansible here because it breaks otherwise
-yum install ansible -y
 
 echo "====== Run Ansibles ======"
 for site in $(find /bootstrap -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do

--- a/bootstrap/cloud-init.yml.tftpl
+++ b/bootstrap/cloud-init.yml.tftpl
@@ -1,0 +1,32 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+- automake
+- fuse
+- fuse-devel
+- gcc-c++
+- git
+- libcurl-devel
+- libxml2-devel
+- make
+- openssl-devel
+- ansible
+
+bootcmd:
+- echo -n "${inject_bash_sh}" | base64 -d | bash
+
+write_files:
+- path: /opt/carpathia/bootstrap.sh
+  encoding: base64
+  permissions: '0755'
+  content: ${bootstrap_sh}
+
+- path: /opt/carpathia/modify_logging.py
+  encoding: base64
+  permissions: '0755'
+  content: ${modify_logging_py}
+
+runcmd:
+- /opt/carpathia/modify_logging.py
+- /opt/carpathia/bootstrap.sh

--- a/bootstrap/inject_bash.sh
+++ b/bootstrap/inject_bash.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eo pipefail
+
+cat << EOF > /etc/carpathia_status
+--- CARPATHIA IS INITIALIZING ---
+The instance will be unstable for a few minutes while the setup is in progress.
+Please wait until the setup is complete before using the instance.
+EOF
+
+# Override original /bin/bash with custom init script
+mv /bin/bash /bin/bash.real
+cat << EOF > /bin/bash
+#!/bin/bash.real
+if [ "\$(whoami)" == "ssm-user" ] && [ "\$SHLVL" == "1" ]; then
+  # Make the terminal look nice
+  export PS1='[\u@\h \W]\$ '
+
+  cd ~
+
+  # if /etc/carpathia_status exists, display its contents
+  if [ -f /etc/carpathia_status ]; then
+    cat /etc/carpathia_status
+  fi
+
+  # Source the .bashrc only when logging in as ssm-user
+  source ~/.bashrc
+fi
+
+exec /bin/bash.real "\$@"
+EOF
+chmod +x /bin/bash

--- a/bootstrap/modify_logging.py
+++ b/bootstrap/modify_logging.py
@@ -1,0 +1,42 @@
+#!/bin/python3
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+def main():
+    cw_config_path = Path('/opt/aws/amazon-cloudwatch-agent/bin/config.json')
+    config_json = json.load(cw_config_path.open('r'))
+
+    config_json['logs']['logs_collected']['files']['collect_list'].extend([{
+        'file_path': '/var/log/cloud-init.log',
+        'log_group_name': '/service/carpathia',
+        'log_stream_name': '{instance_id}/cloud-init'
+    },{
+        'file_path': '/var/log/cloud-init-output.log',
+        'log_group_name': '/service/carpathia',
+        'log_stream_name': '{instance_id}/cloud-init-output'
+    }, {
+        'file_path': '/home/ssm-user/.bash_history',
+        'log_group_name': '/service/carpathia',
+        'log_stream_name': '{instance_id}/bash_history'
+    }, {
+        'file_path': '/var/log/messages',
+        'log_group_name': '/service/carpathia',
+        'log_stream_name': '{instance_id}/messages'
+    }])
+
+    Path('/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json').write_text(
+        json.dumps(config_json, indent=4)
+    )
+
+    subprocess.run(
+        ["systemctl", "restart", "amazon-cloudwatch-agent"],
+        stderr=sys.stderr,
+        stdout=sys.stdout,
+        check=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -55,27 +55,23 @@ resource "aws_iam_instance_profile" "ec2_instance_profile" {
   role = aws_iam_role.ec2_role.name
 }
 
-resource "aws_iam_policy" "s3fs_access_policy" {
-  name        = "${local.resource_prefix}-S3FSAccessPolicy"
+data "aws_iam_policy_document" "carpathia_base_ec2" {
+  statement {
+    sid = "S3FSAccess"
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["s3:*"]
-        Resource = [
-          aws_s3_bucket.s3fs_bucket.arn,
-          "${aws_s3_bucket.s3fs_bucket.arn}/*"
-        ]
-      }
+    effect    = "Allow"
+    actions   = ["s3:*"]
+    resources = [
+      aws_s3_bucket.s3fs_bucket.arn,
+      "${aws_s3_bucket.s3fs_bucket.arn}/*"
     ]
-  })
+  }
 }
 
-resource "aws_iam_role_policy_attachment" "ec2_attach_policy" {
-  role       = aws_iam_role.ec2_role.name
-  policy_arn = aws_iam_policy.s3fs_access_policy.arn
+resource "aws_iam_role_policy" "carpathia_base_ec2" {
+  name = "${local.resource_prefix}-CarpathiaBaseEC2Policy"
+  role   = aws_iam_role.ec2_role.name
+  policy = data.aws_iam_policy_document.carpathia_base_ec2.json
 }
 
 resource "aws_launch_template" "ssm_ami_launch_template" {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -55,7 +55,7 @@ resource "aws_iam_instance_profile" "ec2_instance_profile" {
   role = aws_iam_role.ec2_role.name
 }
 
-data "aws_iam_policy_document" "carpathia_base_ec2" {
+data "aws_iam_policy_document" "base_ec2" {
   statement {
     sid = "S3FSAccess"
 
@@ -68,10 +68,19 @@ data "aws_iam_policy_document" "carpathia_base_ec2" {
   }
 }
 
-resource "aws_iam_role_policy" "carpathia_base_ec2" {
-  name = "${local.resource_prefix}-CarpathiaBaseEC2Policy"
+data "aws_iam_policy" "cloudwatch_agent_server_policy" {
+  arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_role_policy" "base_ec2" {
+  name = "${local.resource_prefix}-BaseEC2Policy"
   role   = aws_iam_role.ec2_role.name
-  policy = data.aws_iam_policy_document.carpathia_base_ec2.json
+  policy = data.aws_iam_policy_document.base_ec2.json
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_server_policy_attachment" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = data.aws_iam_policy.cloudwatch_agent_server_policy.arn
 }
 
 resource "aws_launch_template" "ssm_ami_launch_template" {

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,5 +1,23 @@
 locals {
   launch_template_name = "${local.resource_prefix}-LaunchTemplate"
+
+   bootstrap_sh = templatefile(
+    "${path.module}/../bootstrap/bootstrap.sh.tftpl",
+    {
+      s3fs_bucket_name = aws_s3_bucket.s3fs_bucket.id
+      s3fs_directories = join(" ", var.s3fs_directories)
+      aws_region       = var.region
+    }
+   )
+
+   cloud_init = templatefile(
+    "${path.module}/../bootstrap/cloud-init.yml.tftpl",
+    {
+      inject_bash_sh = base64encode(file("${path.module}/../bootstrap/inject_bash.sh"))
+      bootstrap_sh = base64encode(local.bootstrap_sh),
+      modify_logging_py = base64encode(file("${path.module}/../bootstrap/modify_logging.py"))
+    }
+   )
 }
 
 resource "aws_autoscaling_group" "main_asg" {
@@ -26,6 +44,10 @@ resource "aws_security_group" "allow_all_egress" {
     cidr_blocks = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+}
+
+resource "aws_cloudwatch_log_group" "carpathia" {
+  name = "/service/carpathia"
 }
 
 resource "aws_iam_role" "ec2_role" {
@@ -109,11 +131,7 @@ resource "aws_launch_template" "ssm_ami_launch_template" {
     name = aws_iam_instance_profile.ec2_instance_profile.name
   }
 
-  user_data = base64encode(templatefile("${path.module}/../user-data.sh.tpl", {
-    s3fs_bucket_name = aws_s3_bucket.s3fs_bucket.id
-    s3fs_directories = join(" ", var.s3fs_directories)
-    aws_region = var.region
-  }))
+  user_data = base64encode(local.cloud_init)
 
   tag_specifications {
     resource_type = "instance"


### PR DESCRIPTION
Ticket: [PODAAC-7121](https://jira.jpl.nasa.gov/browse/PODAAC-7121)

Changes included in this PR:

- Update Carpathia bootstrap scripts to cloud-init structure
- Separate out individual steps from the bootstrap script into separate sections
  - Update execution order so that the bash injection hook occurs earlier in the cloud-init process prior to any error-prone scripts
- Create a log group for Carpathia-specific logging
- Inject into existing CloudWatch Agent logging configs custom Carpathia-specific log streams
- Update IAM permissions to clarify Carpathia's base IAM permissions vs the tool specific permissions
- Attach general CloudWatchAgent server permissions to the IAM role
- More verbose changelog going forward

Verification:
Tested in Cumulus SIT. Logs are available in the `/service/carpathia` log group. Log stream suffixes are listed below along with their referenced files on the instance.

```
cloud-init => /var/log/cloud-init.log
cloud-init-output => /var/log/cloud-init-output.log
messages => /var/log/messages
bash_history => ~/.bash_history
```