### PR TITLE
Make NGAP Role Boundaries Optional

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -50,6 +50,11 @@ resource "aws_cloudwatch_log_group" "carpathia" {
   name = "/service/carpathia"
 }
 
+data "aws_iam_policy" "ngap_sh_role_boundary" {
+  count = var.permissions_boundary_policy_name != null ? 1 : 0
+  name = var.permissions_boundary_policy_name
+}
+
 resource "aws_iam_role" "ec2_role" {
   name = "${local.resource_prefix}-ec2-role"
 
@@ -64,7 +69,7 @@ resource "aws_iam_role" "ec2_role" {
     }]
   })
 
-  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
+  permissions_boundary = var.permissions_boundary_policy_name != null ? data.aws_iam_policy.ngap_sh_role_boundary[0].arn : null
 }
 
 resource "aws_iam_role_policy_attachment" "ec2_role_attachment" {

--- a/terraform/envs/ops-cumulus.env
+++ b/terraform/envs/ops-cumulus.env
@@ -2,3 +2,4 @@ export REGION=us-west-2
 export BUCKET=podaac-ops-cumulus-tf-state
 export TF_VAR_rotation_period=0
 export TF_VAR_instance_size=t3.large
+export TF_VAR_permissions_boundary_policy_name="NGAPShRoleBoundary"

--- a/terraform/envs/sit-services.env
+++ b/terraform/envs/sit-services.env
@@ -1,2 +1,3 @@
 export REGION=us-west-2
 export BUCKET=podaac-services-sit-terraform
+export TF_VAR_permissions_boundary_policy_name="NGAPShRoleBoundary"

--- a/terraform/envs/uat-cumulus.env
+++ b/terraform/envs/uat-cumulus.env
@@ -2,3 +2,4 @@ export REGION=us-west-2
 export BUCKET=podaac-uat-cumulus-tf-state
 export TF_VAR_rotation_period=0
 export TF_VAR_instance_size=t3.large
+export TF_VAR_permissions_boundary_policy_name="NGAPShRoleBoundary"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,3 +71,8 @@ variable "notification_emails" {
   default = []
   description = "Email addresses to notify when AMI rotation occurs."
 }
+
+variable "permissions_boundary_policy_name" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
Strange behavior observed in certain environments where NGAP role boundaries seem to be missing from AWS IAM policies. In order to work around this, this branch has developers explicitly state if an environment is expected to have a role boundary policy to use; otherwise it will default to no role boundary within the EC2 IAM role.