### PR TITLE
Fix bootstrap failure caused by Development Tools group install pulling conflicting packages and .env files updates with default values

### DIFF
--- a/bootstrap/bootstrap.sh.tftpl
+++ b/bootstrap/bootstrap.sh.tftpl
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eo pipefail
+exec > >(tee /var/log/bootstrap.log) 2>&1
+set -x
 
 # --- Configuration Variables ---
 BUCKET_NAME="${s3fs_bucket_name}"
@@ -14,7 +16,7 @@ SSM_GID="${ssm_gid}"
 function error_handler {
     cat << EOF > /etc/carpathia_status
 --- CARPATHIA INITIALIZATION FAILED ---
-Check /var/log/cloud-init-output.log for details.
+Check /var/log/cloud-init-output.log and /var/log/bootstrap.log for details.
 EOF
 }
 trap error_handler ERR
@@ -44,13 +46,24 @@ chmod 1777 /tmp
 
 echo "====== 2. OS Update & Python ${python_version} Installation ======"
 dnf update -y --nobest
-# Install Python ${python_version} and the headers required for building C-extensions (Pandas/Numpy)
 dnf install ${python_cmd} ${python_cmd}-pip ${python_cmd}-devel -y
-dnf groupinstall "Development Tools" -y
-dnf install -y gcc-c++ libffi-devel fuse fuse-devel libcurl-devel libxml2-devel openssl-devel mailcap git
+dnf install -y \
+  gcc \
+  gcc-c++ \
+  make \
+  automake \
+  autoconf \
+  libtool \
+  libffi-devel \
+  fuse \
+  fuse-devel \
+  libcurl-devel \
+  libxml2-devel \
+  openssl-devel \
+  mailcap \
+  git
 
 echo "====== 3. Oracle Cleanup ======"
-# Oracle is no longer used. Standardized on Python ${python_version}.
 rm -f /etc/yum.repos.d/oracle-instantclient.repo
 
 echo "====== 4. Build S3FS (v1.95) ======"
@@ -65,11 +78,12 @@ ln -sf /usr/bin/s3fs /sbin/mount.s3fs
 grep -q '^user_allow_other' /etc/fuse.conf || echo 'user_allow_other' >> /etc/fuse.conf
 
 echo "====== 5. S3 Mounts ======"
-id -u ssm-user || adduser -u $SSM_UID -mUG wheel ssm-user
+id -u ssm-user >/dev/null 2>&1 || useradd -u "$SSM_UID" -m -U -G wheel ssm-user
 S3_OPTIONS="_netdev,iam_role=auto,allow_other,use_cache=/data/s3fs-cache,uid=$SSM_UID,gid=$SSM_GID,umask=0022,nonempty,compat_dir,endpoint=$AWS_REGION"
 
 for dir in ${s3fs_directories}; do
-    mkdir -p /$dir
+    dir="$${dir%/}"
+    mkdir -p "/$dir"
     add_fstab_line "s3fs#$BUCKET_NAME:/$dir/ /$dir fuse $S3_OPTIONS 0 0"
 done
 systemctl daemon-reload
@@ -86,12 +100,11 @@ export PIPX_BIN_DIR="$PIPX_BIN_DIR"
 mkdir -p "$PIPX_HOME_DIR"
 export PATH=$PATH:$PIPX_BIN_DIR
 
-# 6a. Pre-install build dependencies for Pandas on ${python_version}
-# We install these globally so --no-build-isolation works in Ansible
+echo "====== 6a. Pre-install Build Dependencies for Pandas ======"
 ${python_cmd} -m pip install --upgrade pip
 ${python_cmd} -m pip install setuptools wheel Cython pandas
 
-# 6b. Install pipx and Ansible
+echo "====== 6b. Install Pipx & Ansible ======"
 ${python_cmd} -m pip install pipx
 pipx install --python ${python_cmd} ansible --force --global --include-deps
 
@@ -100,35 +113,35 @@ ANSIBLE_BIN="$PIPX_HOME_DIR/venvs/ansible/bin/ansible-playbook"
 if mountpoint -q /bootstrap; then
     for site in $(find /bootstrap -mindepth 3 -maxdepth 3 -type f -path "/bootstrap/*/ansible/site.yml"); do
         echo "Running Playbook with Python ${python_version}: $site"
-        # Force ${python_version} interpreter for all modules
         $ANSIBLE_BIN "$site" -v -i localhost, --connection=local -e "ansible_python_interpreter=/usr/bin/${python_cmd}"
     done
 fi
 
-TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
-AMI_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ami-id)
-echo -n "$AMI_ID" > /bootstrap/ami_id
+echo "====== 7a. Capture AMI ID ======"
+TOKEN=$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60" || true)
+AMI_ID=""
+if [ -n "$TOKEN" ]; then
+    AMI_ID=$(curl -fsS -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/ami-id || true)
+fi
+if [ -n "$AMI_ID" ] && mountpoint -q /bootstrap; then
+    echo -n "$AMI_ID" > /bootstrap/ami_id
+fi
 
 echo "====== 8. Finalize Shell Environment ======"
-# Protect the original bash
 [ ! -f /bin/bash.real ] && mv /bin/bash /bin/bash.real
 
 cat << 'EOF' > /bin/bash
 #!/bin/bash.real
 if [ "$(whoami)" == "ssm-user" ] && [ "$SHLVL" == "1" ]; then
-  # 1. Force home directory on login
-  cd ~ 
-  
-  # 2. Update PATH: Add pipx bin and '.' for ops-tools scripts
+  cd ~
+
   export PATH="$PATH:/usr/local/bin:."
   export PIPX_HOME="/opt/pipx"
   export PIPX_BIN_DIR="/usr/local/bin"
-  
-  # 3. Aliases for standard versions
+
   alias python=python${python_version}
   alias pip=pip${python_version}
-  
-  # 4. Standard prompt
+
   export PS1='[\u@\h \W]\$ '
 fi
 exec /bin/bash.real "$@"

--- a/bootstrap/cloud-init.yml.tftpl
+++ b/bootstrap/cloud-init.yml.tftpl
@@ -1,34 +1,16 @@
 #cloud-config
-package_update: true
-package_upgrade: true
-packages:
-- automake
-- fuse
-- fuse-devel
-- gcc-c++
-- git
-- libcurl-devel
-- libxml2-devel
-- make
-- openssl-devel
-- ansible
-- libffi-devel
-- mailcap
-
-bootcmd:
-- echo -n "${inject_bash_sh}" | base64 -d | bash
-
 write_files:
-- path: /opt/carpathia/bootstrap.sh
-  encoding: base64
-  permissions: '0755'
-  content: ${bootstrap_sh}
+  - path: /opt/carpathia/bootstrap.sh
+    encoding: b64
+    permissions: "0755"
+    content: ${bootstrap_sh}
 
-- path: /opt/carpathia/modify_logging.py
-  encoding: base64
-  permissions: '0755'
-  content: ${modify_logging_py}
+  - path: /opt/carpathia/modify_logging.py
+    encoding: b64
+    permissions: "0755"
+    content: ${modify_logging_py}
 
 runcmd:
-- /opt/carpathia/modify_logging.py
-- /opt/carpathia/bootstrap.sh
+  - [ bash, -c, "echo cloud-init-runcmd-started > /tmp/cloud-init-runcmd.txt" ]
+  - [ python3, /opt/carpathia/modify_logging.py ]
+  - [ bash, /opt/carpathia/bootstrap.sh ]

--- a/terraform/envs/sit-swot.env
+++ b/terraform/envs/sit-swot.env
@@ -1,3 +1,4 @@
 export REGION=us-west-2
 export BUCKET=podaac-swot-sit-terraform
 export TF_VAR_rotation_period=30
+export TF_VAR_resource_prefix=podaac-sit-swot-carpathia

--- a/terraform/envs/swot-uat.env
+++ b/terraform/envs/swot-uat.env
@@ -2,3 +2,4 @@ export REGION=us-west-2
 export BUCKET=podaac-swot-uat-cumulus-tf-state
 export TF_VAR_instance_size=t3.medium
 export TF_VAR_rotation_period=0
+export TF_VAR_resource_prefix=podaac-swot-uat-carpathia


### PR DESCRIPTION
# Fix EC2 Bootstrap Failure

## Summary
This PR fixes an EC2 bootstrap failure caused by installing the **Development Tools** package group during instance initialization.

## Problem
The bootstrap script previously used:

`dnf groupinstall "Development Tools" -y`

In some environments this pulled packages like `kernel-devel` that conflicted with the instance’s existing kernel packages. Because the script runs with `set -e`, the failure stopped the rest of the bootstrap process.

## Solution
Replace the group installation with only the required packages:

`dnf install -y gcc gcc-c++ make automake autoconf libtool libffi-devel fuse fuse-devel libcurl-devel libxml2-devel openssl-devel mailcap git`

This avoids the dependency conflict and allows the bootstrap process to complete successfully.