### PR TITLE
Carpathia: s3fs-fuse library to use version 1.94 instead of 1.95

### DIFF
--- a/bootstrap/bootstrap.sh.tftpl
+++ b/bootstrap/bootstrap.sh.tftpl
@@ -66,12 +66,12 @@ dnf install -y \
 echo "====== 3. Oracle Cleanup ======"
 rm -f /etc/yum.repos.d/oracle-instantclient.repo
 
-echo "====== 4. Build S3FS (v1.95) ======"
+echo "====== 4. Build S3FS (v1.94) ======"
 cd /opt
 [ -d s3fs-fuse ] && rm -rf s3fs-fuse
 git clone https://github.com/s3fs-fuse/s3fs-fuse.git
 cd s3fs-fuse
-git checkout v1.95
+git checkout v1.94
 ./autogen.sh && ./configure --prefix=/usr && make -j$(nproc) && make install
 cd /
 ln -sf /usr/bin/s3fs /sbin/mount.s3fs


### PR DESCRIPTION
## Summary
This pull request downgrades the `s3fs-fuse` package version from **1.95** to **1.94**. 

During the deployment of Carpathia to the **C-CUMULUS SIT** environment, we encountered an "Operation not permitted" error when attempting to list files within the s3fs-mounted directory on the newly created EC2 instances. Investigation revealed this was a known regression/issue introduced in `s3fs-fuse` version 1.95. Reverting to version 1.94 successfully resolves the issue.

### Error Encountered
```bash
$ ls -la
ls: reading directory '.': Operation not permitted
```
### Changes
Downgraded s3fs-fuse version dependency from 1.95 to 1.94[cite: 1].

### Testing Conducted
**Environment**: C-CUMULUS SIT

**Verification**: Redeployed the Carpathia EC2 instance with version 1.94 and confirmed that the directory permissions issue is fully resolved (files can now be listed normally via ls -la)

**Sanity Checks**: Conducted baseline tests, including verifying the installation and listing of other required tools on the instance.